### PR TITLE
Store request body as string

### DIFF
--- a/gauge_api_steps/api_steps.py
+++ b/gauge_api_steps/api_steps.py
@@ -99,7 +99,7 @@ def add_header(header_param: str, value_param: str) -> None:
 @step("With body <body>")
 def add_body(body_param: str) -> None:
     body = _substitute(body_param)
-    data_store.scenario[body_key] = bytes(body, "utf8")
+    data_store.scenario[body_key] = body
 
 
 @step("Simulate response body: <value>")
@@ -117,6 +117,8 @@ def make_request(method_param: str, url_param: str) -> None:
         req_csrf_header = data_store.scenario[request_csrf_header_key]
         headers[req_csrf_header] = data_store.scenario[csrf_value_key]
     body = data_store.scenario.pop(body_key, None)
+    if isinstance(body, str):
+        body = body.encode('UTF-8')
     req = Request(url=url, method=method, headers=headers, data=body)
     with _open(req) as resp:
         resp_headers = resp.getheaders()

--- a/tests/test_api_steps.py
+++ b/tests/test_api_steps.py
@@ -1,3 +1,8 @@
+#
+# Copyright IBM Corp. 2019-
+# SPDX-License-Identifier: MIT
+#
+
 import contextlib
 import inspect
 import io

--- a/tests/test_api_steps.py
+++ b/tests/test_api_steps.py
@@ -8,7 +8,10 @@ from getgauge.python import data_store
 from pathlib import Path
 from unittest.mock import Mock
 
-from gauge_api_steps.api_steps import opener_key, append_to_file, beforescenario, pretty_print, response_key, simulate_response
+from gauge_api_steps.api_steps import (
+    opener_key, body_key, response_key,
+    add_body, append_to_file, beforescenario, pretty_print, simulate_response
+)
 
 
 class TestApiSteps(unittest.TestCase):
@@ -25,10 +28,15 @@ class TestApiSteps(unittest.TestCase):
         beforescenario(self.app_context)
         self.assertIsNotNone(data_store.scenario[opener_key])
 
+    def test_add_body(self):
+        body = "body"
+        add_body(body)
+        self.assertEqual(body, data_store.scenario[body_key])
+
     def test_simulate_response(self):
         resp = '{"a": "b"}'
         simulate_response(resp)
-        assert data_store.scenario[response_key]["body"] == resp.encode("UTF-8")
+        self.assertEqual(data_store.scenario[response_key]["body"], resp.encode("UTF-8"))
 
     def test_append(self):
         os.environ["GAUGE_PROJECT_ROOT"] = self.test_dir


### PR DESCRIPTION
The request body should be stored as `str`, so that json/xml operations can be performed on it. Before the actual request, it is transformed to `bytes`.