### PR TITLE
Fixed session property en-/decoding

### DIFF
--- a/gauge_api_steps/api_steps.py
+++ b/gauge_api_steps/api_steps.py
@@ -478,23 +478,17 @@ def _save_session_properties() -> None:
 
 
 def _encode_value(value: str) -> str:
-    """ this transforms any string into a JSON-like str, but keeps non-ascii characters as is. """
+    """ this transforms any string into a format, that can be stored in the session properties file. """
     if value is None:
         return None
-    value = value.replace('\\', '\\\\')
-    value = value.replace('"', '\\"')
-    value = value.replace('\n', '\\n')
-    return f'"{value}"'
+    return value.encode('unicode_escape').decode()
 
 
 def _decode_value(value: str) -> str:
-    """ decodes a JSON-like str. """
-    if value is not None and len(value) >= 2:
-        value = value[1:-1]
-        value = value.replace('\\n', '\n')
-        value = value.replace('\\"', '"')
-        value = value.replace('\\\\', '\\')
-    return value
+    """ decodes a string from the format in the session properties file.  """
+    if value is None:
+        return None
+    return value.encode().decode('unicode_escape')
 
 
 def _store_in_session(key: str, value: str, changed: bool=True) -> None:

--- a/tests/test_api_steps.py
+++ b/tests/test_api_steps.py
@@ -99,9 +99,9 @@ class TestApiSteps(unittest.TestCase):
     def test_load_session_properties(self):
         props_file = f"{self.test_dir}/session.properties"
         os.environ["session_properties"] = props_file
-        data = ('a = "1"\n'
-            'b = ""\n'
-            'c = "{\\n  \\"key\": \\"value\\",\\n  \\"else\\": \\"\\\\0x41\"\\n}"\n')
+        data = ('a = 1\n'
+            'b = \n'
+            'c = {\\n  \\"key\": \\"value\\",\\n  \\"else\\": \\"\\\\0x41\"\\n}\n')
         with patch("builtins.open", mock_open(read_data=data)) as mocked_open, patch("os.path.exists") as mocked_exists:
             mocked_exists.return_value = True
             _load_session_properties()
@@ -130,9 +130,9 @@ class TestApiSteps(unittest.TestCase):
         mocked_open.assert_called_with(f"{props_file}.tmp", 'w')
         handle = mocked_open()
         handle.write.assert_has_calls([
-            call('a = "1"\n'),
-            call('b = ""\n'),
-            call('c = "{\\n  \\"key\\": \\"value\\",\\n  \\"else\\": \\"\\\\0x41\\"\\n}"\n')
+            call('a = 1\n'),
+            call('b = \n'),
+            call('c = {\\n  "key": "value",\\n  "else": "\\\\0x41"\\n}\n')
         ])
         mocked_replace.assert_called_with(f"{props_file}.tmp", props_file)
 


### PR DESCRIPTION
The previous encoding was too custom and there were buggy edge cases, where encoding/decoding would change the value.